### PR TITLE
ibook specification for proper font embedding

### DIFF
--- a/openpecha/serializers/epub.py
+++ b/openpecha/serializers/epub.py
@@ -1,5 +1,8 @@
 import os
 import re
+import shutil
+import zipfile
+from bs4 import BeautifulSoup
 from pathlib import Path
 
 import requests
@@ -403,6 +406,85 @@ class EpubSerializer(Serialize):
                 new_toc_levels[walker] = annotation_xpath
                 walker += 1
         return new_toc_levels
+    
+    def get_new_metadata(self, soup, meta_data):
+        """Update meta data of opf
+
+        Args:
+            soup (bs4-tag): beautiful soup tag of whole opf
+            meta_data (bs4-tag): beautiful soup tag of metadata
+
+        Returns:
+            bs4-tag: new metadata
+        """
+        ibook_meta = soup.new_tag('meta')
+        ibook_meta.attrs['property'] = "ibooks:specified-fonts"
+        ibook_meta.append('true')
+        meta_data.append(ibook_meta)
+        return meta_data
+
+    def get_new_manifest(self, soup, manifest):
+        """Update manifest of opf
+
+        Args:
+            soup (bs4-tag): beautiful soup tag of whole opf
+            manifest (bs4-tag): beautiful soup tag of manifest
+
+        Returns:
+            bs4-tag: new manifest
+        """
+        new_item = soup.new_tag('item')
+        new_item.attrs['href'] = "font/MonlamUniOuChan2.ttf"
+        new_item.attrs['id'] = "MonlamUniOuChan2.ttf"
+        new_item.attrs['media-type'] = "application/x-font-ttf"
+        manifest.append(new_item)
+        return manifest
+
+    def get_new_opf(self, opf):
+        """Updating opf content of epub with ibook specifications
+
+        Args:
+            opf (str): opf content of epub produced by calibre
+
+        Returns:
+            str: new opf content
+        """
+        soup = BeautifulSoup(opf, "html.parser")
+        soup.package.attrs['prefix'] = "ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/"
+        old_meta = soup.find('metadata')
+        old_manifest = soup.find('manifest')
+        new_meta = self.get_new_metadata(soup, old_meta)
+        new_manifest = self.get_new_manifest(soup, old_manifest)
+        soup.metadata.replaceWith(new_meta)
+        soup.manifest.replaceWith(new_manifest)
+        return str(soup)
+
+    def embed_ibook_specific_font(self, epub_path):
+        """Include ibook specification for proper font embedding and recompiling the ebook.
+
+        Args:
+            epub_path (path_obj): path of epub produced by calibre
+        """
+        pecha_id = epub_path.stem
+        #rename to zip
+        epub_path.rename(epub_path.with_suffix('.zip'))
+        zip_path = epub_path.parent / f'{pecha_id}.zip'
+        epub_folder = str(epub_path.parent / f'{pecha_id}')
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(epub_folder)
+        print('INFO: Unzip epub..')
+        zip_path.unlink()
+        opf_path = Path(epub_folder) / 'content.opf'
+        opf_content = opf_path.read_text(encoding='utf-8')
+        new_opf_content = self.get_new_opf(opf_content)
+        opf_path.write_text(new_opf_content, encoding='utf-8')
+        print('INFO: OPF content updated..')
+        new_zip_path = shutil.make_archive(epub_folder, 'zip', epub_folder)
+        os.system(f'rm -r {epub_folder}')
+        print('INFO: file zipped..')
+        new_zip_path = Path(new_zip_path)
+        new_zip_path.rename(new_zip_path.with_suffix('.epub'))
+        print('INFO: Epub ready...')
 
     def serialize(self, toc_levels={}, output_path="./output/epub_output"):
         """This module serialize .opf file to other format such as .epub etc. In case of epub,
@@ -467,5 +549,5 @@ class EpubSerializer(Serialize):
             # Removing html file and template file
             os.system(f"rm {out_html_fn}")
             os.system("rm template.css")
-
+            self.embed_ibook_specific_font(out_epub_fn)
             return out_epub_fn


### PR DESCRIPTION
OPF content of epub produced by calibre changed in order to see embedded font in ibook.
- package tag got introduced to new attribute:
          prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/"
- metadata tag got new element: 
         <meta property="ibooks:specified-fonts">true</meta>
- manifest tag got new element:
         <item href="font/MonlamUniOuChan2.ttf" id="MonlamUniOuChan2.ttf" media-type="application/x-font-ttf"></item>